### PR TITLE
chore: cleanup config for release

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -35,5 +35,5 @@ typescript:
   methodArguments: require-security-and-request
   outputModelSuffix: output
   packageName: dingify
-  responseFormat: envelope-http
+  responseFormat: flat
   templateVersion: v2

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,17 +1,17 @@
-speakeasyVersion: 1.285.0
+speakeasyVersion: 1.285.2
 sources: {}
 targets: {}
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest
     sources:
-        sample-source:
+        dingify-api:
             inputs:
                 - location: openapi.yaml
     targets:
         my-first-target:
             target: typescript
-            source: sample-source
+            source: dingify-api
             publish:
                 npm:
                     token: $npm_token

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ It has been generated successfully based on your OpenAPI spec. However, it is no
 ### NPM
 
 ```bash
-npm add <UNSET>
+npm add https://github.com/Codehagen/dingify-sdk
 ```
 
 ### Yarn
 
 ```bash
-yarn add <UNSET>
+yarn add https://github.com/Codehagen/dingify-sdk
 ```
 <!-- End SDK Installation [installation] -->
 


### PR DESCRIPTION
Changes: 
- Setup flat response for simpler DX https://www.speakeasyapi.dev/docs/customize-sdks/responses#responseformat-flat
- Setup place Github placeholder URL until publishing
- Change source name, purely cosmetic so the workflow is easier to understand

Next Steps: 
- Do a force generate to confirm NPM Publishing works as expected. This will cause a minor bump in the SDK version and trigger a check to republish to NPM. Ensure there is a Github secret of name `NPM_TOKEN` set. Details on type of token to chose [here](https://www.speakeasyapi.dev/docs/advanced-setup/publish-sdks#create-package-manager-credentials). 

![CleanShot 2024-05-09 at 13 29 14](https://github.com/Codehagen/dingify-sdk/assets/68016351/1690e61c-6e00-4dd8-bcd3-0392595a12b3)
